### PR TITLE
Fix build with clang16

### DIFF
--- a/decoder.c
+++ b/decoder.c
@@ -94,7 +94,7 @@ static int handle_bool(void *ctx, int value)
     return PlaceObject(ctx, PyBool_FromLong((long)(value)));
 }
 
-static int handle_number(void *ctx, const char *value, unsigned int length)
+static int handle_number(void *ctx, const char *value, size_t length)
 {
     //fprintf(stderr, "handle_number: ");
     //fwrite(value, length, 1, stderr);
@@ -127,7 +127,7 @@ static int handle_number(void *ctx, const char *value, unsigned int length)
     return status;
 }
 
-static int handle_string(void *ctx, const unsigned char *value, unsigned int length)
+static int handle_string(void *ctx, const unsigned char *value, size_t length)
 {
     return PlaceObject(ctx, PyString_FromStringAndSize((char *)value, length));
 }
@@ -142,7 +142,7 @@ static int handle_start_dict(void *ctx)
     return success;
 }
 
-static int handle_dict_key(void *ctx, const unsigned char *value, unsigned int length)
+static int handle_dict_key(void *ctx, const unsigned char *value, size_t length)
 {
     PyObject *object = PyString_FromStringAndSize((const char *) value, length);
 

--- a/yajl.c
+++ b/yajl.c
@@ -84,7 +84,7 @@ static PyObject *py_loads(PYARGS)
     return result;
 }
 
-const char* IndentString(int n) {
+char* IndentString(int n) {
     char* spaces = (char *)(malloc(n + 1));
     memset(spaces, ' ', n);
     spaces[n] = '\0';
@@ -161,7 +161,7 @@ static PyObject *py_load(PYARGS)
 }
 
 static struct PyMethodDef yajl_methods[] = {
-    {"dumps", (PyCFunctionWithKeywords)(py_dumps), METH_VARARGS | METH_KEYWORDS,
+    {"dumps", (PyCFunction)(py_dumps), METH_VARARGS | METH_KEYWORDS,
 "yajl.dumps(obj [, indent=None])\n\n\
 Returns an encoded JSON string of the specified `obj`\n\
 \n\
@@ -196,5 +196,6 @@ json.dumps():\t\t7760.6348ms\n\
 simplejson.dumps():\t930.9748ms\n\
 yajl.dumps():\t\t681.0221ms"
 );
+    (void)module;
 }
 


### PR DESCRIPTION
Newer clang versions do less implicit type conversions (probably a good thing). Luckily some minor corrections are sufficient to fix the build.